### PR TITLE
Implement serial command for reading and writing raw config

### DIFF
--- a/include/config/Config.h
+++ b/include/config/Config.h
@@ -13,11 +13,13 @@
 namespace OpenShock::Config {
   void Init();
 
-  /* Get the config file translated to JSON. */
+  /* GetAsJSON and SaveFromJSON are used for Reading/Writing the config file in its human-readable form. */
   std::string GetAsJSON();
-
-  /* Save the config file from JSON. */
   bool SaveFromJSON(const std::string& json);
+
+  /* GetRaw and SetRaw are used for Reading/Writing the config file in its binary form. */
+  bool GetRaw(std::vector<std::uint8_t>& buffer);
+  bool SetRaw(const std::uint8_t* buffer, std::size_t size);
 
   /**
    * @brief Resets the config file to the factory default values.

--- a/include/util/Base64Utils.h
+++ b/include/util/Base64Utils.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <mbedtls/base64.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+// IMPORTANT: WE DONT USE ARRAYS OR TEMPLATES HERE
+
+namespace OpenShock::Base64Utils {
+  /// @brief Calculates the size of the buffer required to hold the base64 encoded data.
+  /// @param size The size of the data to encode.
+  /// @return The size of the buffer required to hold the base64 encoded data.
+  constexpr std::size_t CalculateEncodedSize(std::size_t size) noexcept {
+    return (size + 2) / 3 * 4;
+  }
+
+  /// @brief Calculates the size of the buffer required to hold the decoded data.
+  /// @param size The size of the data to decode.
+  /// @return The size of the buffer required to hold the decoded data.
+  constexpr std::size_t CalculateDecodedSize(std::size_t size) noexcept {
+    return (size + 3) / 4 * 3;
+  }
+
+  /// @brief Encodes a byte array to base64.
+  /// @param data The data to encode.
+  /// @param dataLen The size of the data to encode.
+  /// @param output
+  /// @param outputLen
+  /// @return The amount of bytes written to the output buffer.
+  inline std::size_t Encode(const std::uint8_t* data, std::size_t dataLen, char* output, std::size_t outputLen) noexcept {
+    std::size_t written = 0;
+    if (mbedtls_base64_encode(reinterpret_cast<std::uint8_t*>(output), outputLen, &written, data, dataLen) != 0) {
+      return 0;
+    }
+    return written;
+  }
+
+  /// @brief Encodes a byte array to base64.
+  /// @param data The data to encode.
+  /// @param dataLen The size of the data to encode.
+  /// @param output The output string to write to.
+  /// @return The amount of bytes written to the output buffer.
+  inline std::size_t Encode(const std::uint8_t* data, std::size_t dataLen, std::string& output) noexcept {
+    std::size_t outputLen = CalculateEncodedSize(dataLen);
+    output.resize(outputLen);
+    return Encode(data, dataLen, const_cast<char*>(output.data()), output.size());
+  }
+
+  /// @brief Decodes a base64 string.
+  /// @param data The data to decode.
+  /// @param dataLen The size of the data to decode.
+  /// @param output The output buffer to write to.
+  /// @param outputLen The size of the output buffer.
+  /// @return The amount of bytes written to the output buffer.
+  inline std::size_t Decode(const char* data, std::size_t dataLen, std::uint8_t* output, std::size_t outputLen) noexcept {
+    std::size_t written = 0;
+    if (mbedtls_base64_decode(output, outputLen, &written, reinterpret_cast<const std::uint8_t*>(data), dataLen) != 0) {
+      return 0;
+    }
+    return written;
+  }
+
+  /// @brief Decodes a base64 string.
+  /// @param data The data to decode.
+  /// @param dataLen The size of the data to decode.
+  /// @param output The output buffer to write to.
+  /// @return The amount of bytes written to the output buffer.
+  inline std::size_t Decode(const char* data, std::size_t dataLen, std::vector<std::uint8_t>& output) noexcept {
+    std::size_t outputLen = CalculateDecodedSize(dataLen);
+    output.resize(outputLen);
+    return Decode(data, dataLen, output.data(), outputLen);
+  }
+}  // namespace OpenShock::Base64Utils

--- a/include/util/Base64Utils.h
+++ b/include/util/Base64Utils.h
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <mbedtls/base64.h>
-
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <vector>
 
 // IMPORTANT: WE DONT USE ARRAYS OR TEMPLATES HERE
 
@@ -13,14 +12,14 @@ namespace OpenShock::Base64Utils {
   /// @param size The size of the data to encode.
   /// @return The size of the buffer required to hold the base64 encoded data.
   constexpr std::size_t CalculateEncodedSize(std::size_t size) noexcept {
-    return (size + 2) / 3 * 4;
+    return (4 * (size / 3)) + 4; // TODO: This is wrong, but what mbedtls requires???
   }
 
   /// @brief Calculates the size of the buffer required to hold the decoded data.
   /// @param size The size of the data to decode.
   /// @return The size of the buffer required to hold the decoded data.
   constexpr std::size_t CalculateDecodedSize(std::size_t size) noexcept {
-    return (size + 3) / 4 * 3;
+    return 3 * size / 4;
   }
 
   /// @brief Encodes a byte array to base64.
@@ -29,24 +28,14 @@ namespace OpenShock::Base64Utils {
   /// @param output
   /// @param outputLen
   /// @return The amount of bytes written to the output buffer.
-  inline std::size_t Encode(const std::uint8_t* data, std::size_t dataLen, char* output, std::size_t outputLen) noexcept {
-    std::size_t written = 0;
-    if (mbedtls_base64_encode(reinterpret_cast<std::uint8_t*>(output), outputLen, &written, data, dataLen) != 0) {
-      return 0;
-    }
-    return written;
-  }
+  std::size_t Encode(const std::uint8_t* data, std::size_t dataLen, char* output, std::size_t outputLen) noexcept;
 
   /// @brief Encodes a byte array to base64.
   /// @param data The data to encode.
   /// @param dataLen The size of the data to encode.
   /// @param output The output string to write to.
   /// @return The amount of bytes written to the output buffer.
-  inline bool Encode(const std::uint8_t* data, std::size_t dataLen, std::string& output) noexcept {
-    std::size_t outputLen = CalculateEncodedSize(dataLen);
-    output.resize(outputLen);
-    return Encode(data, dataLen, const_cast<char*>(output.data()), output.size()) != 0;
-  }
+  bool Encode(const std::uint8_t* data, std::size_t dataLen, std::string& output) noexcept;
 
   /// @brief Decodes a base64 string.
   /// @param data The data to decode.
@@ -54,22 +43,12 @@ namespace OpenShock::Base64Utils {
   /// @param output The output buffer to write to.
   /// @param outputLen The size of the output buffer.
   /// @return The amount of bytes written to the output buffer.
-  inline std::size_t Decode(const char* data, std::size_t dataLen, std::uint8_t* output, std::size_t outputLen) noexcept {
-    std::size_t written = 0;
-    if (mbedtls_base64_decode(output, outputLen, &written, reinterpret_cast<const std::uint8_t*>(data), dataLen) != 0) {
-      return 0;
-    }
-    return written;
-  }
+  std::size_t Decode(const char* data, std::size_t dataLen, std::uint8_t* output, std::size_t outputLen) noexcept;
 
   /// @brief Decodes a base64 string.
   /// @param data The data to decode.
   /// @param dataLen The size of the data to decode.
   /// @param output The output buffer to write to.
   /// @return The amount of bytes written to the output buffer.
-  inline bool Decode(const char* data, std::size_t dataLen, std::vector<std::uint8_t>& output) noexcept {
-    std::size_t outputLen = CalculateDecodedSize(dataLen);
-    output.resize(outputLen);
-    return Decode(data, dataLen, output.data(), outputLen) != 0;
-  }
+  bool Decode(const char* data, std::size_t dataLen, std::vector<std::uint8_t>& output) noexcept;
 }  // namespace OpenShock::Base64Utils

--- a/include/util/Base64Utils.h
+++ b/include/util/Base64Utils.h
@@ -42,10 +42,10 @@ namespace OpenShock::Base64Utils {
   /// @param dataLen The size of the data to encode.
   /// @param output The output string to write to.
   /// @return The amount of bytes written to the output buffer.
-  inline std::size_t Encode(const std::uint8_t* data, std::size_t dataLen, std::string& output) noexcept {
+  inline bool Encode(const std::uint8_t* data, std::size_t dataLen, std::string& output) noexcept {
     std::size_t outputLen = CalculateEncodedSize(dataLen);
     output.resize(outputLen);
-    return Encode(data, dataLen, const_cast<char*>(output.data()), output.size());
+    return Encode(data, dataLen, const_cast<char*>(output.data()), output.size()) != 0;
   }
 
   /// @brief Decodes a base64 string.
@@ -67,9 +67,9 @@ namespace OpenShock::Base64Utils {
   /// @param dataLen The size of the data to decode.
   /// @param output The output buffer to write to.
   /// @return The amount of bytes written to the output buffer.
-  inline std::size_t Decode(const char* data, std::size_t dataLen, std::vector<std::uint8_t>& output) noexcept {
+  inline bool Decode(const char* data, std::size_t dataLen, std::vector<std::uint8_t>& output) noexcept {
     std::size_t outputLen = CalculateDecodedSize(dataLen);
     output.resize(outputLen);
-    return Decode(data, dataLen, output.data(), outputLen);
+    return Decode(data, dataLen, output.data(), outputLen) != 0;
   }
 }  // namespace OpenShock::Base64Utils

--- a/src/SerialInputHandler.cpp
+++ b/src/SerialInputHandler.cpp
@@ -338,6 +338,7 @@ void _handleRawConfigCommand(char* arg, std::size_t argLength) {
     }
 
     SERPR_RESPONSE("RawConfig|%s", base64.c_str());
+    return;
   }
 
   std::vector<std::uint8_t> buffer;

--- a/src/util/Base64Utils.cpp
+++ b/src/util/Base64Utils.cpp
@@ -1,0 +1,77 @@
+#include "util/Base64Utils.h"
+
+#include "Logging.h"
+
+#include <mbedtls/base64.h>
+
+const char* const TAG = "Base64Utils";
+
+using namespace OpenShock;
+
+std::size_t Base64Utils::Encode(const std::uint8_t* data, std::size_t dataLen, char* output, std::size_t outputLen) noexcept {
+  std::size_t requiredLen = 0;
+
+  int retval = mbedtls_base64_encode(reinterpret_cast<std::uint8_t*>(output), outputLen, &requiredLen, data, dataLen);
+  if (retval != 0) {
+    if (retval == MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+      ESP_LOGW(TAG, "Output buffer too small (expected %zu, got %zu)", requiredLen, outputLen);
+    } else {
+      ESP_LOGW(TAG, "Failed to encode data, unknown error: %d", retval);
+    }
+    return 0;
+  }
+
+  return requiredLen;
+}
+
+bool Base64Utils::Encode(const std::uint8_t* data, std::size_t dataLen, std::string& output) noexcept {
+  std::size_t requiredLen = Base64Utils::CalculateEncodedSize(dataLen) + 1; // +1 for null terminator
+  output.resize(requiredLen);
+
+  std::size_t written = Encode(data, dataLen, const_cast<char*>(output.data()), output.size());
+  if (written == 0) {
+    output.clear();
+    return false;
+  }
+
+  if (written < requiredLen) {
+    output.resize(written);
+  }
+
+  return true;
+}
+
+std::size_t Base64Utils::Decode(const char* data, std::size_t dataLen, std::uint8_t* output, std::size_t outputLen) noexcept {
+  std::size_t requiredLen = 0;
+
+  int retval = mbedtls_base64_decode(output, outputLen, &requiredLen, reinterpret_cast<const std::uint8_t*>(data), dataLen);
+  if (retval != 0) {
+    if (retval == MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+      ESP_LOGW(TAG, "Output buffer too small (expected %zu, got %zu)", requiredLen, outputLen);
+    } else if (retval == MBEDTLS_ERR_BASE64_INVALID_CHARACTER) {
+      ESP_LOGW(TAG, "Invalid character in input data");
+    } else {
+      ESP_LOGW(TAG, "Failed to decode data, unknown error: %d", retval);
+    }
+    return 0;
+  }
+
+  return requiredLen;
+}
+
+bool Base64Utils::Decode(const char* data, std::size_t dataLen, std::vector<std::uint8_t>& output) noexcept {
+  std::size_t requiredLen = Base64Utils::CalculateDecodedSize(dataLen);
+  output.resize(requiredLen);
+
+  std::size_t written = Decode(data, dataLen, output.data(), output.size());
+  if (written == 0) {
+    output.clear();
+    return false;
+  }
+
+  if (written < requiredLen) {
+    output.resize(written);
+  }
+
+  return true;
+}


### PR DESCRIPTION
This is useful for copying the config between devices, across reflashes of a device, or for parsing it externally with flatbuffers.