### PR TITLE
[Feature] Captive Portal: DNS Server + Redirects (triggers login popup on devices)

### DIFF
--- a/include/CaptivePortalInstance.h
+++ b/include/CaptivePortalInstance.h
@@ -2,6 +2,7 @@
 
 #include "WebSocketDeFragger.h"
 
+#include <DNSServer.h>
 #include <ESPAsyncWebServer.h>
 #include <WebSocketsServer.h>
 
@@ -31,6 +32,7 @@ namespace OpenShock {
     AsyncWebServer m_webServer;
     WebSocketsServer m_socketServer;
     WebSocketDeFragger m_socketDeFragger;
+    DNSServer m_dnsServer;
     TaskHandle_t m_taskHandle;
   };
 }  // namespace OpenShock

--- a/src/CaptivePortalInstance.cpp
+++ b/src/CaptivePortalInstance.cpp
@@ -18,6 +18,7 @@ static const char* TAG = "CaptivePortalInstance";
 
 constexpr std::uint16_t HTTP_PORT                 = 80;
 constexpr std::uint16_t WEBSOCKET_PORT            = 81;
+constexpr std::uint16_t DNS_PORT                  = 53;
 constexpr std::uint32_t WEBSOCKET_PING_INTERVAL   = 10'000;
 constexpr std::uint32_t WEBSOCKET_PING_TIMEOUT    = 1000;
 constexpr std::uint8_t WEBSOCKET_PING_RETRIES     = 3;
@@ -80,10 +81,14 @@ CaptivePortalInstance::CaptivePortalInstance()
   : m_webServer(HTTP_PORT)
   , m_socketServer(WEBSOCKET_PORT, "/ws", "json")
   , m_socketDeFragger(std::bind(&CaptivePortalInstance::handleWebSocketEvent, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4))
+  , m_dnsServer()
   , m_taskHandle(nullptr) {
   m_socketServer.onEvent(std::bind(&WebSocketDeFragger::handler, &m_socketDeFragger, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
   m_socketServer.begin();
   m_socketServer.enableHeartbeat(WEBSOCKET_PING_INTERVAL, WEBSOCKET_PING_TIMEOUT, WEBSOCKET_PING_RETRIES);
+
+  ESP_LOGI(TAG, "Setting up DNS server");
+  m_dnsServer.start(DNS_PORT, "*", WiFi.softAPIP());
 
   // Check if the www folder exists and is populated
   bool indexExists = LittleFS.exists("/www/index.html.gz");
@@ -97,9 +102,14 @@ CaptivePortalInstance::CaptivePortalInstance()
     ESP_LOGI(TAG, "Serving files from LittleFS");
     ESP_LOGI(TAG, "Filesystem hash: %s", fsHash);
 
+    char softAPURL[64];
+    snprintf(softAPURL, sizeof(softAPURL), "http://%s", WiFi.softAPIP().toString().c_str());
+
+    // Serving the captive portal files from LittleFS
     m_webServer.serveStatic("/", LittleFS, "/www/", "max-age=3600").setDefaultFile("index.html").setSharedEtag(fsHash);
 
-    m_webServer.onNotFound([](AsyncWebServerRequest* request) { request->send(404, "text/plain", "Not found"); });
+    // Redirecting connection tests to the captive portal, triggering the "login to network" prompt
+    m_webServer.onNotFound([softAPURL](AsyncWebServerRequest* request) { request->redirect(softAPURL); });
   } else {
     ESP_LOGE(TAG, "/www/index.html or hash files not found, serving error page");
 
@@ -135,6 +145,7 @@ CaptivePortalInstance::~CaptivePortalInstance() {
   }
   m_webServer.end();
   m_socketServer.close();
+  m_dnsServer.stop();
 }
 
 void CaptivePortalInstance::task(void* arg) {
@@ -142,6 +153,7 @@ void CaptivePortalInstance::task(void* arg) {
 
   while (true) {
     instance->m_socketServer.loop();
+    instance->m_dnsServer.processNextRequest();
     vTaskDelay(pdMS_TO_TICKS(WEBSOCKET_UPDATE_INTERVAL));
   }
 }


### PR DESCRIPTION
Our captive portal was more just a portal than a *captive* one. :P

This follows the expectation that we answer to a device's DNS and HTTP connection tests in a way that it prompts the user for further action. (By redirecting all of those tests to ourselves.)

Further reading, if we decide to react to each test instead of the catch-all "404 Not Found" adjustment:

https://github.com/CDFER/Captive-Portal-ESP32/blob/main/src/main.cpp#L89