### PR TITLE
Support Wemos S3 Mini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -63,13 +63,15 @@ custom_openshock.flash_size = 16MB
 build_flags =
 	-DOPENSHOCK_LED_WS2812B=38
 
-; https://docs.platformio.org/en/latest/boards/espressif32/lolin_s3.html
+; https://docs.platformio.org/en/latest/boards/espressif32/lolin_s3_mini.html
 [env:Wemos-Lolin-S3-Mini]
 board = lolin_s3_mini ; builtin
 custom_openshock.chip = ESP32-S3
 custom_openshock.flash_size = 4MB
 build_flags =
 	-DOPENSHOCK_LED_WS2812B=47
+    -DOPENSHOCK_LED_FLIP_RG_CHANNELS=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
 
 [env:Pishock-2023]
 board = Wemos-D1-Mini-ESP32 ; override

--- a/platformio.ini
+++ b/platformio.ini
@@ -63,6 +63,14 @@ custom_openshock.flash_size = 16MB
 build_flags =
 	-DOPENSHOCK_LED_WS2812B=38
 
+; https://docs.platformio.org/en/latest/boards/espressif32/lolin_s3.html
+[env:Wemos-Lolin-S3-Mini]
+board = lolin_s3_mini ; builtin
+custom_openshock.chip = ESP32-S3
+custom_openshock.flash_size = 4MB
+build_flags =
+	-DOPENSHOCK_LED_WS2812B=47
+
 [env:Pishock-2023]
 board = Wemos-D1-Mini-ESP32 ; override
 custom_openshock.chip = ESP32

--- a/platformio.ini
+++ b/platformio.ini
@@ -70,8 +70,8 @@ custom_openshock.chip = ESP32-S3
 custom_openshock.flash_size = 4MB
 build_flags =
 	-DOPENSHOCK_LED_WS2812B=47
-    -DOPENSHOCK_LED_FLIP_RG_CHANNELS=1
-    -DARDUINO_USB_CDC_ON_BOOT=1
+	-DOPENSHOCK_LED_FLIP_RG_CHANNELS=1
+	-DARDUINO_USB_CDC_ON_BOOT=1
 
 [env:Pishock-2023]
 board = Wemos-D1-Mini-ESP32 ; override

--- a/scripts/use_openshock_params.py
+++ b/scripts/use_openshock_params.py
@@ -46,8 +46,10 @@ def use_openshock_params():
         print('WARNING: OTA NOT SUPPORTED FOR THIS FLASH SIZE.')
         print('Using Non-OTA partition layout.')
         board_config.update('build.partitions', str(partitions))
+        board_config.update('upload.flash_size', boardconf.get_flash_size())
     else:   
         board_config.update('build.partitions', str(partitions_ota))
+        board_config.update('upload.flash_size', boardconf.get_flash_size())
 
 
 print_header()

--- a/src/RGBPatternManager.cpp
+++ b/src/RGBPatternManager.cpp
@@ -97,12 +97,21 @@ void RGBPatternManager::RunPattern(void* arg) {
 
   while (true) {
     for (const auto& state : pattern) {
+      // WS2812B usually takes commands in GRB order
+      // https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf - Page 5
+      // But some actually expect RGB!
+
+#if defined(OPENSHOCK_LED_FLIP_RG_CHANNELS) && OPENSHOCK_LED_FLIP_RG_CHANNELS
+      // Default, GRB
+      std::uint8_t g = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.red) * brightness / 255);
+      std::uint8_t r = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.green) * brightness / 255);
+#else
+      // Default, GRB
       std::uint8_t r = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.red) * brightness / 255);
       std::uint8_t g = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.green) * brightness / 255);
+#endif
       std::uint8_t b = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.blue) * brightness / 255);
 
-      // WS2812B takes commands in GRB order
-      // https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf - Page 5
       const std::uint32_t colors = (static_cast<std::uint32_t>(g) << 16) | (static_cast<std::uint32_t>(r) << 8) | static_cast<std::uint32_t>(b);
 
       // Encode the data

--- a/src/RGBPatternManager.cpp
+++ b/src/RGBPatternManager.cpp
@@ -101,16 +101,12 @@ void RGBPatternManager::RunPattern(void* arg) {
       // https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf - Page 5
       // But some actually expect RGB!
 
-#if defined(OPENSHOCK_LED_FLIP_RG_CHANNELS) && OPENSHOCK_LED_FLIP_RG_CHANNELS
-      // RG Flipped, RGB
-      std::uint8_t g = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.red) * brightness / 255);
-      std::uint8_t r = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.green) * brightness / 255);
-#else
-      // Default, GRB
       std::uint8_t r = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.red) * brightness / 255);
       std::uint8_t g = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.green) * brightness / 255);
-#endif
       std::uint8_t b = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.blue) * brightness / 255);
+#if OPENSHOCK_LED_FLIP_RG_CHANNELS
+      std::swap(r, g);
+#endif
 
       const std::uint32_t colors = (static_cast<std::uint32_t>(g) << 16) | (static_cast<std::uint32_t>(r) << 8) | static_cast<std::uint32_t>(b);
 

--- a/src/RGBPatternManager.cpp
+++ b/src/RGBPatternManager.cpp
@@ -102,7 +102,7 @@ void RGBPatternManager::RunPattern(void* arg) {
       // But some actually expect RGB!
 
 #if defined(OPENSHOCK_LED_FLIP_RG_CHANNELS) && OPENSHOCK_LED_FLIP_RG_CHANNELS
-      // Default, GRB
+      // RG Flipped, RGB
       std::uint8_t g = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.red) * brightness / 255);
       std::uint8_t r = static_cast<std::uint8_t>(static_cast<std::uint16_t>(state.green) * brightness / 255);
 #else


### PR DESCRIPTION
Had to declare the target's size in another spot so that the compiled bootloader points at correct offsets.

Plus, the user's board and my board both have odd RGB leds that have the R and G channels flipped. Since we're still using defines for now, I just added a simple one to flip those channels when building for this board.

