### PR TITLE
Use more recent esptool version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,12 @@ extra_scripts =
   pre:scripts/embed_env_vars.py
   post:scripts/build_frontend.py
 
+; PlatformIO-compatible packages
+platform_packages =
+  ; Force-updating esptool until PlatformIO finally updates their copy
+  ; https://github.com/platformio/platform-espressif32/issues/1417
+  tool-esptoolpy @ https://github.com/OpenShock/esptool.git#platformio-json
+
 ; Serial Monitor options
 upload_speed = 921600
 monitor_speed = 115200

--- a/scripts/install_dependencies.py
+++ b/scripts/install_dependencies.py
@@ -37,9 +37,12 @@ class Package:
 
 # List of packages to install (pip name, package name)
 required = [
+    # Captive Portal building
     Package('fonttools', ['woff', 'unicode'], 'fontTools'),
     Package('brotli', [], 'brotli'),
     Package('gitpython', [], 'git'),
+    # esptool (while using custom version)
+    Package('intelhex', [], "IntelHex"),
 ]
 
 # Get all packages that are not installed


### PR DESCRIPTION
Until PlatformIO updates their distributed copy, we'll have to use a [fork](https://github.com/OpenShock/esptool) of `esptool` to get the most recent changes (which improve reliability of uploading/erasing operations during development).