### PR TITLE
feat: :wrench: Add support for NodeMCU and uPesy

### DIFF
--- a/include/Chipset.h
+++ b/include/Chipset.h
@@ -207,6 +207,9 @@
 #ifdef OPENSHOCK_FW_BOARD_DFROBOTFIREBEETLE2ESP32E
 #define OPENSHOCK_BYPASSED_GPIO(pin) ((pin) == 2 || (pin) == 5)
 #endif
+#ifdef OPENSHOCK_FW_BOARD_NODEMCU32S
+#define OPENSHOCK_BYPASSED_GPIO(pin) ((pin) == 2)
+#endif
 #ifndef OPENSHOCK_BYPASSED_GPIO
 #define OPENSHOCK_BYPASSED_GPIO(pin) (false)
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -156,8 +156,19 @@ build_flags = ${env.build_flags}
 	-DOPENSHOCK_ESTOP_PIN=38
 	-DARDUINO_USB_CDC_ON_BOOT=1
 
-; TODO:
-; https://docs.platformio.org/en/latest/boards/espressif32/upesy_wroom.html;upesy-esp32-wroom-devkit
+; https://docs.platformio.org/en/stable/boards/espressif32/nodemcu-32s.html
+[env:NodeMCU-32S]
+board = nodemcu-32s
+custom_openshock.chip = ESP32
+build_flags = ${env.build_flags}
+	-DOPENSHOCK_LED_GPIO=2
+
+; https://docs.platformio.org/en/latest/boards/espressif32/upesy_wroom.html
+; untested, but compiles fine
+[env:uPesy-ESP32-Wroom-DevKit]
+board = upesy_wroom
+custom_openshock.chip = ESP32
+build_flags = ${env.build_flags}
 
 [env:fs]
 custom_openshock.chip = ESP32


### PR DESCRIPTION
Adds NodeMCU-32S and uPesy-ESP32 as build targets