### PR TITLE
Handle automated serial commands

### DIFF
--- a/include/serial/command_handlers/common.h
+++ b/include/serial/command_handlers/common.h
@@ -6,9 +6,10 @@
 
 #include <Arduino.h>
 
-#define SERPR_SYS(format, ...)      ::Serial.printf("$SYS$|" format "\n", ##__VA_ARGS__)
-#define SERPR_RESPONSE(format, ...) SERPR_SYS("Response|" format, ##__VA_ARGS__)
-#define SERPR_SUCCESS(format, ...)  SERPR_SYS("Success|" format, ##__VA_ARGS__)
-#define SERPR_ERROR(format, ...)    SERPR_SYS("Error|" format, ##__VA_ARGS__)
+namespace OpenShock::Serial::Util {
+  void respError(bool isAutomated, const char* format, ...);
+}
+
+#define CLEAR_LINE "\r\x1B[K"
 
 using namespace std::string_view_literals;

--- a/src/serial/SerialInputHandler.cpp
+++ b/src/serial/SerialInputHandler.cpp
@@ -272,8 +272,6 @@ void RegisterCommandHandler(const OpenShock::Serial::CommandGroup& handler)
   s_commandHandlers[handler.name()] = handler;
 }
 
-#define CLEAR_LINE "\r\x1B[K"
-
 class SerialBuffer {
   DISABLE_COPY(SerialBuffer);
   DISABLE_MOVE(SerialBuffer);

--- a/src/serial/command_handlers/common.cpp
+++ b/src/serial/command_handlers/common.cpp
@@ -1,0 +1,30 @@
+#include "serial/command_handlers/common.h"
+
+#include <cJSON.h>
+
+using namespace OpenShock;
+
+void Serial::Util::respError(bool isAutomated, const char* format, ...)
+{
+  if (isAutomated) {
+    cJSON* root = cJSON_CreateObject();
+    if (root == nullptr) {
+      ::Serial.printf(CLEAR_LINE "Failed to create JSON object\n");
+      return;
+    }
+
+    cJSON_AddStringToObject(root, "error", msg);
+
+    char* out = cJSON_PrintUnformatted(root);
+
+    if (out != nullptr) {
+      ::Serial.printf("$SYS$%s\n", out);
+      cJSON_free(out);
+    }
+
+    cJSON_Delete(root);
+    return;
+  }
+
+  ::Serial.printf(CLEAR_LINE "Error: %s\n", msg);
+}


### PR DESCRIPTION
Example is OpenShock relay, or automated configuration of the hub.
These will be prefixed by $ and be handled completely differently by the firmware to make hub to software communication better.