### PR TITLE
Add support for AliExpress variant of EPS32-S3 Zero

### DIFF
--- a/boards/Generic-ESP32-S3-FH4R2.json
+++ b/boards/Generic-ESP32-S3-FH4R2.json
@@ -1,0 +1,56 @@
+{
+    "build": {
+      "arduino":{
+        "partitions": "default.csv",
+        "memory_type": "qio_qspi"
+      },
+      "core": "esp32",
+      "extra_flags": [
+        "-DARDUINO_ESP32S3_DEV",
+        "-DARDUINO_RUNNING_CORE=1",
+        "-DARDUINO_EVENT_RUNNING_CORE=1",
+        "-DARDUINO_USB_CDC_ON_BOOT=1",
+        "-DBOARD_HAS_PSRAM"
+      ],
+      "f_cpu": "240000000L",
+      "f_flash": "80000000L",
+      "flash_mode": "qio",
+      "psram_type": "qio",
+      "hwids": [
+        [
+          "0x303A",
+          "0x1001"
+        ]
+      ],
+      "mcu": "esp32s3",
+      "variant": "esp32s3"
+    },
+    "connectivity": [
+      "wifi",
+      "bluetooth"
+    ],
+    "debug": {
+      "default_tool": "esp-builtin",
+      "onboard_tools": [
+        "esp-builtin"
+      ],
+      "openocd_target": "esp32s3.cfg"
+    },
+    "frameworks": [
+      "arduino",
+      "espidf"
+    ],
+    "platforms" : [
+      "espressif32"
+    ],
+    "name": "Espressif ESP32-S3-FH4R2 (4 MB QD, 2MB PSRAM)",
+    "upload": {
+      "flash_size": "4MB",
+      "maximum_ram_size": 327680,
+      "maximum_size": 4194304,
+      "require_upload_port": true,
+      "speed": 921600
+    },
+    "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+    "vendor": "Espressif"
+  }

--- a/platformio.ini
+++ b/platformio.ini
@@ -162,6 +162,18 @@ custom_openshock.chip = ESP32
 build_flags = ${env.build_flags}
 	-DOPENSHOCK_LED_GPIO=2
 
+; AliExpress ESP32-S3 SuperMini / Waveshare ESP32-S3 Zero clone
+; Different pin layout than original
+; 4MB Flash, 2MB PSRAM.
+[env:ESP-S3-SuperMini]
+board = Generic-ESP32-S3-FH4R2
+custom_openshock.chip = ESP32-S3
+custom_openshock.flash_size = 4MB
+build_flags = ${env.build_flags}
+	-DOPENSHOCK_LED_WS2812B=48
+	-DOPENSHOCK_RF_TX_GPIO=13
+	-DARDUINO_USB_CDC_ON_BOOT=1
+
 ; TODO:
 ; https://docs.platformio.org/en/latest/boards/espressif32/upesy_wroom.html;upesy-esp32-wroom-devkit
 


### PR DESCRIPTION
The Waveshare ESP32-S3 Zero is already supported, but the readily accessible and cheap (sub 5$) clone board of it that's sold on AliExpress has more pins and a different layout (LED on a different pin, TX/RX and 3.3V/GND pins swapped places).
This pull request adds a board config for all generic ESP32-S3-FH4R2 boards and the platformio config for the AliExpress clone of the Zero called ESP32-S3-SuperMini. (Example: https://de.aliexpress.com/item/1005006583245248.html)

Pin 13 has been chosen as the default for the 433mhz module, because it's right next to GND and 3.3V making it the cleanest default in my opinion.