### PR TITLE
fix: no more crashing on some knockoff boards after network connects

### DIFF
--- a/src/GatewayConnectionManager.cpp
+++ b/src/GatewayConnectionManager.cpp
@@ -264,7 +264,7 @@ bool StartConnectingToLCG()
     return false;
   }
 
-  OS_LOGD(TAG, "Connecting to LCG endpoint { host: '%s', port: %hu, path: '%s' } %s in country %s", response.data.host.c_str(), response.data.port, response.data.path.c_str(), response.data.country.c_str());
+  OS_LOGD(TAG, "Connecting to LCG endpoint { host: '%s', port: %hu, path: '%s' } in country %s", response.data.host.c_str(), response.data.port, response.data.path.c_str(), response.data.country.c_str());
   s_wsClient->connect(response.data.host, response.data.port, response.data.path);
 
   return true;


### PR DESCRIPTION
Removed an unused `%s` placeholder in GatewayConnectionManager.cpp:267 which was causing some knockoff boards to crash after network connects.