### PR TITLE
Improve EStop Manager's atomics + set to Idle when changing pin/enabled.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -68,7 +68,7 @@ AlignTrailingComments:
   OverEmptyLines: 1
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: Always
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: InlineOnly

--- a/include/estop/EStopManager.h
+++ b/include/estop/EStopManager.h
@@ -13,5 +13,5 @@ namespace OpenShock::EStopManager {
   bool IsEStopped();
   int64_t LastEStopped();
 
-  void Trigger();
+  void SoftwareTrigger();
 }  // namespace OpenShock::EStopManager

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -23,9 +23,9 @@ const char* const TAG = "EStopManager";
 using namespace OpenShock;
 
 const uint32_t k_estopHoldToClearTime = 5000;
-const uint32_t k_estopUpdateRate      = 5;   // 200 Hz
-const uint32_t k_estopCheckCount      = 13;  // 65 ms at 200 Hz
-const uint16_t k_estopCheckMask       = 0xFFFF >> ((sizeof(uint16_t) * 8) - k_estopCheckCount); // Mask to check only last k_estopCheckCount bits within history
+const uint32_t k_estopUpdateRate      = 5;                                                       // 200 Hz
+const uint32_t k_estopCheckCount      = 13;                                                      // 65 ms at 200 Hz
+const uint16_t k_estopCheckMask       = 0xFFFF >> ((sizeof(uint16_t) * 8) - k_estopCheckCount);  // Mask to check only last k_estopCheckCount bits within history
 
 // Grace period after deactivation (prevents immediate re-trigger on release bounce/EMI)
 const uint32_t k_estopRearmGraceTime = 250;  // tune as needed
@@ -36,8 +36,8 @@ static TaskHandle_t s_estopTask = nullptr;
 static gpio_num_t s_estopPin    = GPIO_NUM_NC;  // Passed to task via pointer argument
 
 // Wrapped in atomics as they're read (or set via public methods) by Tasks potentially running on other cores.
-static std::atomic<int64_t> s_estopActivatedAt = 0; // When == 0, EStop not active. When != 0, EStop is active.
-static std::atomic<bool> s_externallyTriggered = false;
+static std::atomic<int64_t> s_estopActivatedAt       = 0;  // When == 0, EStop not active. When != 0, EStop is active.
+static std::atomic<bool> s_externallyTriggered       = false;
 static std::atomic<bool> s_killEStopManagerRequested = false;
 
 static bool s_estopInitialized = false;
@@ -47,7 +47,7 @@ static void estopmgr_publishState(EStopState state, EStopState& lastState)
   if (state == lastState) {
     return;  // No state change -> no event
   }
-  
+
   // Post the current state as the event payload
   esp_err_t err = esp_event_post(OPENSHOCK_EVENTS, OPENSHOCK_EVENT_ESTOP_STATE_CHANGED, &state, sizeof(state), pdMS_TO_TICKS(750));
 
@@ -73,7 +73,7 @@ static void estopmgr_managerTask(void* pvParameters)
   uint16_t history = 0xFFFF;  // Bit history of samples, 0 is pressed
 
   int64_t deactivatesAt = 0;
-  
+
   // Rearm grace state
   int64_t rearmAt   = 0;
   bool rearmBlocked = false;
@@ -83,7 +83,6 @@ static void estopmgr_managerTask(void* pvParameters)
 
   // Check if killing manager was requested, continue looping otherwise
   while (!s_killEStopManagerRequested.load(std::memory_order_relaxed)) {
-
     // Sleep for the update rate
     vTaskDelay(pdMS_TO_TICKS(k_estopUpdateRate));
 
@@ -94,7 +93,7 @@ static void estopmgr_managerTask(void* pvParameters)
     if (s_externallyTriggered.exchange(false, std::memory_order_relaxed)) {
       int64_t zero = 0;
       s_estopActivatedAt.compare_exchange_strong(zero, now, std::memory_order_relaxed);
-      
+
       state        = EStopState::Active;
       rearmBlocked = false;
 
@@ -241,7 +240,7 @@ static bool estopmgr_taskStart()
       OS_LOGW(TAG, "No valid pin is defined, refusing to start task");
       return false;
     }
-    
+
     if (!estopmgr_setPinImpl(pin)) {
       OS_LOGE(TAG, "Failed to set EStop pin");
       return false;
@@ -252,14 +251,14 @@ static bool estopmgr_taskStart()
 
   // Tiny hack;
   // We are passing pin as a pointer, the pointer memory address being the value of the pin.
-  // 
+  //
   // A pointer after all is just a integer with a special meaning, arg pointer isn't being used for anything so we can use it for this.
-  // 
+  //
   // This also proves to be safer than using atomics for this since we know for sure that the pin we intended the task to run with
   // will not change between creating the task and it freezing its local copy of the value.
-  // 
+  //
   // This enables us to use no allocations or atomic operations
-  static_assert(sizeof(void*) >= sizeof(gpio_num_t), "void* is smaller than gpio_num_t, value embedding trick wont work"); // Just to be safe
+  static_assert(sizeof(void*) >= sizeof(gpio_num_t), "void* is smaller than gpio_num_t, value embedding trick wont work");  // Just to be safe
   void* argPtr = reinterpret_cast<void*>(static_cast<intptr_t>(s_estopPin));
 
   if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, 4096, argPtr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
@@ -279,7 +278,7 @@ static bool estopmgr_taskStop()
   }
 
   s_killEStopManagerRequested.store(true, std::memory_order_relaxed);
-  
+
   TaskUtils::StopTask(s_estopTask, TAG, "EStop task");
   s_estopTask = nullptr;
 

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -93,12 +93,13 @@ static void estopmgr_managerTask(void* pvParameters)
 
     // Handle external trigger: forcibly set the E-Stop active.
     if (s_externallyTriggered.exchange(false, std::memory_order_acquire)) {
-      s_estopActivatedAt.compare_exchange_strong(0, now, std::memory_order_acq_rel);
+      int64_t zero = 0;
+      s_estopActivatedAt.compare_exchange_strong(zero, now, std::memory_order_acq_rel);
       
       state        = EStopState::Active;
       rearmBlocked = false;
 
-      estopmgr_PublishState(state, lastPublishedState);
+      estopmgr_publishState(state, lastPublishedState);
 
       // Do not modify history/lastBtnState here; rely on physical button state
       // on subsequent iterations.
@@ -168,11 +169,11 @@ static void estopmgr_managerTask(void* pvParameters)
         break;
     }
 
-    estopmgr_PublishState(state, lastPublishedState);
+    estopmgr_publishState(state, lastPublishedState);
   }
 
   // Broke out of main loop, set global variables to Idle state.
-  estopmgr_PublishState(EStopState::Idle, lastPublishedState);
+  estopmgr_publishState(EStopState::Idle, lastPublishedState);
   s_estopActivatedAt.store(0, std::memory_order_relaxed);
 
   vTaskDelete(nullptr);
@@ -183,7 +184,7 @@ static bool estopmgr_setEStopEnabled(bool enabled)
   if (enabled) {
     if (s_estopTask == nullptr) {
       s_killEStopManagerRequested.store(false, std::memory_order_acquire);
-      if (TaskUtils::TaskCreateUniversal(estopmgr_ManagerTask, TAG, 4096, nullptr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
+      if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, 4096, nullptr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
         OS_LOGE(TAG, "Failed to create EStop event handler task");
         s_estopTask = nullptr;
         return false;

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -25,72 +25,54 @@ using namespace OpenShock;
 const uint32_t k_estopHoldToClearTime = 5000;
 const uint32_t k_estopUpdateRate      = 5;   // 200 Hz
 const uint32_t k_estopCheckCount      = 13;  // 65 ms at 200 Hz
-const uint16_t k_estopCheckMask       = 0xFFFF >> ((sizeof(uint16_t) * 8) - k_estopCheckCount);
+const uint16_t k_estopCheckMask       = 0xFFFF >> ((sizeof(uint16_t) * 8) - k_estopCheckCount); // Mask to check only last k_estopCheckCount bits within history
 
 // Grace period after deactivation (prevents immediate re-trigger on release bounce/EMI)
 const uint32_t k_estopRearmGraceTime = 250;  // tune as needed
 
 static OpenShock::SimpleMutex s_estopMutex = {};
-static gpio_num_t s_estopPin               = GPIO_NUM_NC;
+// Guarded via Mutex
 static TaskHandle_t s_estopTask            = nullptr;
 
-static EStopState s_lastPublishedState         = EStopState::Idle;
-static std::atomic<bool> s_estopActive         = false;
-static std::atomic<int64_t> s_estopActivatedAt = 0;
-
+// Wrapped in atomics as they're read (or set via public methods) by Tasks potentially running on other cores.
+static std::atomic<gpio_num_t> s_estopPin  = GPIO_NUM_NC;
+static std::atomic<int64_t> s_estopActivatedAt = 0; // When == 0, EStop not active. When != 0, EStop is active.
 static std::atomic<bool> s_externallyTriggered = false;
-static std::atomic<bool> s_runEstopTask  = false;
+static std::atomic<bool> s_killEStopManagerRequested = false;
 
 static bool s_estopInitialized = false;
 
-static void estopmanager_updateexternals(EStopState state)
+static void estopmgr_PublishState(EStopState state, EStopState& lastState)
 {
-  if (state == s_lastPublishedState) {
+  if (state == lastState) {
     return;  // No state change -> no event
   }
-
-  s_lastPublishedState = state;
-
+  
   // Post the current state as the event payload
-  ESP_ERROR_CHECK(esp_event_post(OPENSHOCK_EVENTS, OPENSHOCK_EVENT_ESTOP_STATE_CHANGED, &state, sizeof(state), portMAX_DELAY));
-}
+  esp_err_t err = esp_event_post(OPENSHOCK_EVENTS, OPENSHOCK_EVENT_ESTOP_STATE_CHANGED, &state, sizeof(state), pdMS_TO_TICKS(750));
 
-static void trigger_estop(int64_t time) {
-  if (!s_estopActive.exchange(true, std::memory_order_relaxed)) {
-    s_estopActivatedAt.store(time, std::memory_order_relaxed);
+  if (err == ESP_OK) {
+    lastState = state;
+  } else {
+    OS_LOGE(TAG, "Failed to publish EStop event");
   }
-}
-
-static void clear_estop() {
-  s_estopActivatedAt.store(false, std::memory_order_relaxed);
-}
-
-static bool check_externally_triggered() {
-  return s_externallyTriggered.exchange(false, std::memory_order_relaxed);
-}
-
-static void set_estop_task_run(bool value) {
-  s_runEstopTask.store(value, std::memory_order_relaxed);
-}
-static bool estop_task_run() {
-  return s_runEstopTask.load(std::memory_order_relaxed);
 }
 
 // Samples the estop at a fixed rate and updates internal state + events
-static void estopmgr_checkertask(void* pvParameters)
+static void estopmgr_ManagerTask(void* pvParameters)
 {
-  (void)pvParameters;
-
   // Ensure known initial state
-  s_lastPublishedState = EStopState::Idle;
-  s_estopActive.store(false, std::memory_order_relaxed);
   s_estopActivatedAt.store(0, std::memory_order_relaxed);
+
+  gpio_num_t estopPin = s_estopPin.load(std::memory_order_relaxed);
+
+  EStopState state              = EStopState::Idle;
+  EStopState lastPublishedState = EStopState::Idle;
 
   uint16_t history = 0xFFFF;  // Bit history of samples, 0 is pressed
 
-  EStopState state      = EStopState::Idle;
   int64_t deactivatesAt = 0;
-
+  
   // Rearm grace state
   int64_t rearmAt   = 0;
   bool rearmBlocked = false;
@@ -98,7 +80,10 @@ static void estopmgr_checkertask(void* pvParameters)
   // Debounced button state: true == pressed, false == released
   bool lastBtnState = false;
 
-  while (estop_task_run()) {
+  for (;;) {
+    // Check if killing manager was requested
+    if (s_killEStopManagerRequested.load(std::memory_order_relaxed)) break;
+
     // Sleep for the update rate
     vTaskDelay(pdMS_TO_TICKS(k_estopUpdateRate));
 
@@ -106,20 +91,23 @@ static void estopmgr_checkertask(void* pvParameters)
     int64_t now = OpenShock::millis();
 
     // Handle external trigger: forcibly set the E-Stop active.
-    if (check_externally_triggered()) {
-      trigger_estop(now);
+    if (s_externallyTriggered.exchange(false, std::memory_order_acquire)) {
+      if (s_estopActivatedAt.load(std::memory_order_acquire) == 0) {
+        s_estopActivatedAt.store(now, std::memory_order_release);
+      }
+      
       state        = EStopState::Active;
       rearmBlocked = false;
 
-      estopmanager_updateexternals(state);
+      estopmgr_PublishState(state, lastPublishedState);
 
-      // Do not modify history/lastBtnState here; allow hardware to take over
+      // Do not modify history/lastBtnState here; rely on physical button state
       // on subsequent iterations.
       continue;
     }
 
     // Sample the EStop input
-    history = static_cast<uint16_t>((history << 1) | gpio_get_level(s_estopPin));
+    history = static_cast<uint16_t>((history << 1) | gpio_get_level(estopPin));
 
     // Debounce:
     // If all recent bits are 1 -> fully released.
@@ -144,7 +132,7 @@ static void estopmgr_checkertask(void* pvParameters)
 
         if (btnState) {
           state = EStopState::Active;
-          trigger_estop(now);
+          s_estopActivatedAt.store(now, std::memory_order_relaxed);
         }
         break;
 
@@ -168,7 +156,7 @@ static void estopmgr_checkertask(void* pvParameters)
       case EStopState::AwaitingRelease:
         if (!btnState) {  // fully released -> clear E-Stop
           state = EStopState::Idle;
-          clear_estop();
+          s_estopActivatedAt.store(0, std::memory_order_relaxed);
 
           // Start grace period to prevent immediate re-trigger.
           rearmBlocked = true;
@@ -181,35 +169,45 @@ static void estopmgr_checkertask(void* pvParameters)
         break;
     }
 
-    estopmanager_updateexternals(state);
+    estopmgr_PublishState(state, lastPublishedState);
   }
+
+  // Broke out of main loop, set global variables to Idle state.
+  estopmgr_PublishState(EStopState::Idle, lastPublishedState);
+  s_estopActivatedAt.store(0, std::memory_order_relaxed);
 
   vTaskDelete(nullptr);
 }
 
-static bool estopmgr_setestopenabled(bool enabled)
+static bool estopmgr_setEStopEnabled(bool enabled)
 {
   if (enabled) {
     if (s_estopTask == nullptr) {
-      set_estop_task_run(true);
-      if (TaskUtils::TaskCreateUniversal(estopmgr_checkertask, TAG, 4096, nullptr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
+      s_killEStopManagerRequested.store(false, std::memory_order_acquire);
+      if (TaskUtils::TaskCreateUniversal(estopmgr_ManagerTask, TAG, 4096, nullptr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
         OS_LOGE(TAG, "Failed to create EStop event handler task");
         s_estopTask = nullptr;
         return false;
       }
+    } else {
+      OS_LOGW(TAG, "Tried to enable EStop manager, but was already running");
     }
   } else {
     if (s_estopTask != nullptr) {
-      set_estop_task_run(false);
+      s_killEStopManagerRequested.store(true, std::memory_order_acquire);
+      s_estopActivatedAt.store(0, std::memory_order_relaxed);
+      
       TaskUtils::StopTask(s_estopTask, TAG, "EStop task");
       s_estopTask = nullptr;
+    } else {
+      OS_LOGW(TAG, "Tried to kill EStop manager, but was not running");
     }
   }
 
   return true;
 }
 
-static bool estopmgr_set_pin_impl(gpio_num_t pin)
+static bool estopmgr_setPinImpl(gpio_num_t pin)
 {
   esp_err_t err;
 
@@ -224,7 +222,7 @@ static bool estopmgr_set_pin_impl(gpio_num_t pin)
 
   bool wasRunning = s_estopTask != nullptr;
   if (wasRunning) {
-    if (!estopmgr_setestopenabled(false)) {
+    if (!estopmgr_setEStopEnabled(false)) {
       OS_LOGE(TAG, "Failed to disable EStop event handler task");
       return false;
     }
@@ -260,7 +258,7 @@ static bool estopmgr_set_pin_impl(gpio_num_t pin)
   }
 
   if (wasRunning) {
-    if (!estopmgr_setestopenabled(true)) {
+    if (!estopmgr_setEStopEnabled(true)) {
       OS_LOGE(TAG, "Failed to re-enable EStop event handler task");
       return false;
     }
@@ -284,12 +282,12 @@ bool EStopManager::Init()
 
   OpenShock::ScopedLock lock__(&s_estopMutex);
 
-  if (!estopmgr_set_pin_impl(cfg.gpioPin)) {
+  if (!estopmgr_setPinImpl(cfg.gpioPin)) {
     OS_LOGE(TAG, "Failed to set EStop pin");
     return false;
   }
 
-  if (!estopmgr_setestopenabled(cfg.enabled)) {
+  if (!estopmgr_setEStopEnabled(cfg.enabled)) {
     OS_LOGE(TAG, "Failed to create EStop event handler task");
     return false;
   }
@@ -307,33 +305,33 @@ bool EStopManager::SetEStopEnabled(bool enabled)
       OS_LOGE(TAG, "Failed to get EStop pin from config");
       return false;
     }
-    if (!estopmgr_set_pin_impl(pin)) {
+    if (!estopmgr_setPinImpl(pin)) {
       OS_LOGE(TAG, "Failed to set EStop pin");
       return false;
     }
   }
 
-  return estopmgr_setestopenabled(enabled);
+  return estopmgr_setEStopEnabled(enabled);
 }
 
 bool EStopManager::SetEStopPin(gpio_num_t pin)
 {
   OpenShock::ScopedLock lock__(&s_estopMutex);
 
-  return estopmgr_set_pin_impl(pin);
+  return estopmgr_setPinImpl(pin);
 }
 
 bool EStopManager::IsEStopped()
 {
-  return s_estopActive.load(std::memory_order_relaxed);
+  return EStopManager::LastEStopped() != 0;
 }
 
 int64_t EStopManager::LastEStopped()
 {
-  return s_estopActivatedAt.load(std::memory_order_relaxed);
+  return s_estopActivatedAt.load(std::memory_order_acquire);
 }
 
-void EStopManager::Trigger()
+void EStopManager::SoftwareTrigger()
 {
   // This will be picked up by the checker task and lead to an E-Stop activation
   s_externallyTriggered.store(true, std::memory_order_relaxed);

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -32,10 +32,10 @@ const uint32_t k_estopRearmGraceTime = 250;  // tune as needed
 
 static OpenShock::SimpleMutex s_estopMutex = {};
 // Guarded via Mutex
-static TaskHandle_t s_estopTask            = nullptr;
+static TaskHandle_t s_estopTask = nullptr;
+static gpio_num_t s_estopPin    = GPIO_NUM_NC;  // Passed to task via pointer argument
 
 // Wrapped in atomics as they're read (or set via public methods) by Tasks potentially running on other cores.
-static std::atomic<gpio_num_t> s_estopPin  = GPIO_NUM_NC;
 static std::atomic<int64_t> s_estopActivatedAt = 0; // When == 0, EStop not active. When != 0, EStop is active.
 static std::atomic<bool> s_externallyTriggered = false;
 static std::atomic<bool> s_killEStopManagerRequested = false;
@@ -61,12 +61,11 @@ static void estopmgr_publishState(EStopState state, EStopState& lastState)
 // Samples the estop at a fixed rate and updates internal state + events
 static void estopmgr_managerTask(void* pvParameters)
 {
-  (void)pvParameters;
+  // Pin is being passed as a pointer, cast it back to gpio number type to get pin value
+  gpio_num_t estopPin = static_cast<gpio_num_t>(reinterpret_cast<intptr_t>(pvParameters));
 
   // Ensure known initial state
   s_estopActivatedAt.store(0, std::memory_order_relaxed);
-
-  gpio_num_t estopPin = s_estopPin.load(std::memory_order_relaxed);
 
   EStopState state              = EStopState::Idle;
   EStopState lastPublishedState = EStopState::Idle;
@@ -92,9 +91,9 @@ static void estopmgr_managerTask(void* pvParameters)
     int64_t now = OpenShock::millis();
 
     // Handle external trigger: forcibly set the E-Stop active.
-    if (s_externallyTriggered.exchange(false, std::memory_order_acquire)) {
+    if (s_externallyTriggered.exchange(false, std::memory_order_relaxed)) {
       int64_t zero = 0;
-      s_estopActivatedAt.compare_exchange_strong(zero, now, std::memory_order_acquire);
+      s_estopActivatedAt.compare_exchange_strong(zero, now, std::memory_order_relaxed);
       
       state        = EStopState::Active;
       rearmBlocked = false;
@@ -179,53 +178,17 @@ static void estopmgr_managerTask(void* pvParameters)
   vTaskDelete(nullptr);
 }
 
-static bool estopmgr_setEStopEnabled(bool enabled)
-{
-  if (enabled) {
-    if (s_estopTask == nullptr) {
-      s_killEStopManagerRequested.store(false, std::memory_order_release);
-      if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, 4096, nullptr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
-        OS_LOGE(TAG, "Failed to create EStop event handler task");
-        s_estopTask = nullptr;
-        return false;
-      }
-    } else {
-      OS_LOGW(TAG, "Tried to enable EStop manager, but was already running");
-    }
-  } else {
-    if (s_estopTask != nullptr) {
-      s_killEStopManagerRequested.store(true, std::memory_order_release);
-      s_estopActivatedAt.store(0, std::memory_order_relaxed);
-      
-      TaskUtils::StopTask(s_estopTask, TAG, "EStop task");
-      s_estopTask = nullptr;
-    } else {
-      OS_LOGW(TAG, "Tried to kill EStop manager, but was not running");
-    }
-  }
-
-  return true;
-}
-
 static bool estopmgr_setPinImpl(gpio_num_t pin)
 {
   esp_err_t err;
-
-  if (s_estopPin == pin) {
-    return true;
-  }
 
   if (!OpenShock::IsValidInputPin(pin)) {
     OS_LOGE(TAG, "Invalid EStop pin: %hhi", static_cast<int8_t>(pin));
     return false;
   }
 
-  bool wasRunning = s_estopTask != nullptr;
-  if (wasRunning) {
-    if (!estopmgr_setEStopEnabled(false)) {
-      OS_LOGE(TAG, "Failed to disable EStop event handler task");
-      return false;
-    }
+  if (s_estopPin == pin) {
+    return true;
   }
 
   // Configure the new pin
@@ -243,10 +206,10 @@ static bool estopmgr_setPinImpl(gpio_num_t pin)
     return false;
   }
 
-  gpio_num_t oldPin = s_estopPin.load(std::memory_order_acquire);
+  gpio_num_t oldPin = s_estopPin;
 
   // Set the new pin
-  s_estopPin.store(pin, std::memory_order_release);
+  s_estopPin = pin;
 
   if (oldPin != GPIO_NUM_NC) {
     // Reset the old pin
@@ -257,12 +220,71 @@ static bool estopmgr_setPinImpl(gpio_num_t pin)
     }
   }
 
-  if (wasRunning) {
-    if (!estopmgr_setEStopEnabled(true)) {
-      OS_LOGE(TAG, "Failed to re-enable EStop event handler task");
+  return true;
+}
+
+static bool estopmgr_taskStart()
+{
+  if (s_estopTask != nullptr) {
+    OS_LOGW(TAG, "Tried to enable EStop manager, but was already running");
+    return true;
+  }
+
+  if (s_estopPin == GPIO_NUM_NC) {
+    gpio_num_t pin;
+    if (!OpenShock::Config::GetEStopGpioPin(pin)) {
+      OS_LOGE(TAG, "Failed to get EStop pin from config");
+      return false;
+    }
+
+    if (pin == GPIO_NUM_NC) {
+      OS_LOGW(TAG, "No valid pin is defined, refusing to start task");
+      return false;
+    }
+    
+    if (!estopmgr_setPinImpl(pin)) {
+      OS_LOGE(TAG, "Failed to set EStop pin");
       return false;
     }
   }
+
+  s_killEStopManagerRequested.store(false, std::memory_order_relaxed);
+
+  // Tiny hack;
+  // We are passing pin as a pointer, the pointer memory address being the value of the pin.
+  // 
+  // A pointer after all is just a integer with a special meaning, arg pointer isn't being used for anything so we can use it for this.
+  // 
+  // This also proves to be safer than using atomics for this since we know for sure that the pin we intended the task to run with
+  // will not change between creating the task and it freezing its local copy of the value.
+  // 
+  // This enables us to use no allocations or atomic operations
+  static_assert(sizeof(void*) >= sizeof(gpio_num_t), "void* is smaller than gpio_num_t, value embedding trick wont work"); // Just to be safe
+  void* argPtr = reinterpret_cast<void*>(static_cast<intptr_t>(s_estopPin));
+
+  if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, 4096, argPtr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
+    OS_LOGE(TAG, "Failed to create EStop event handler task");
+    s_estopTask = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+static bool estopmgr_taskStop()
+{
+  if (s_estopTask == nullptr) {
+    OS_LOGW(TAG, "Tried to kill EStop manager, but was not running");
+    return true;
+  }
+
+  s_killEStopManagerRequested.store(true, std::memory_order_relaxed);
+  
+  TaskUtils::StopTask(s_estopTask, TAG, "EStop task");
+  s_estopTask = nullptr;
+
+  // Disable E-Stop after task has stopped to ensure that the task didn't get it stuck in enabled state
+  s_estopActivatedAt.store(0, std::memory_order_relaxed);
 
   return true;
 }
@@ -280,6 +302,10 @@ bool EStopManager::Init()
     return false;
   }
 
+  if (!cfg.enabled) {
+    return true;
+  }
+
   OpenShock::ScopedLock lock__(&s_estopMutex);
 
   if (!estopmgr_setPinImpl(cfg.gpioPin)) {
@@ -287,38 +313,48 @@ bool EStopManager::Init()
     return false;
   }
 
-  if (!estopmgr_setEStopEnabled(cfg.enabled)) {
-    OS_LOGE(TAG, "Failed to create EStop event handler task");
-    return false;
-  }
-
-  return true;
+  return estopmgr_taskStart();
 }
 
 bool EStopManager::SetEStopEnabled(bool enabled)
 {
   OpenShock::ScopedLock lock__(&s_estopMutex);
 
-  if (s_estopPin == GPIO_NUM_NC) {
-    gpio_num_t pin;
-    if (!OpenShock::Config::GetEStopGpioPin(pin)) {
-      OS_LOGE(TAG, "Failed to get EStop pin from config");
-      return false;
-    }
-    if (!estopmgr_setPinImpl(pin)) {
-      OS_LOGE(TAG, "Failed to set EStop pin");
-      return false;
-    }
+  if (enabled) {
+    return estopmgr_taskStart();
+  } else {
+    return estopmgr_taskStop();
   }
-
-  return estopmgr_setEStopEnabled(enabled);
 }
 
 bool EStopManager::SetEStopPin(gpio_num_t pin)
 {
   OpenShock::ScopedLock lock__(&s_estopMutex);
 
-  return estopmgr_setPinImpl(pin);
+  // Check pin validity before stopping possibly running task
+  if (!OpenShock::IsValidInputPin(pin)) {
+    OS_LOGE(TAG, "Invalid EStop pin: %hhi", static_cast<int8_t>(pin));
+    return false;
+  }
+
+  if (s_estopPin == pin) {
+    return true;
+  }
+
+  bool wasRunning = s_estopTask != nullptr;
+  if (wasRunning && !estopmgr_taskStop()) {
+    return false;
+  }
+
+  if (!estopmgr_setPinImpl(pin)) {
+    return false;
+  }
+
+  if (wasRunning && !estopmgr_taskStart()) {
+    return false;
+  }
+
+  return true;
 }
 
 bool EStopManager::IsEStopped()
@@ -328,7 +364,7 @@ bool EStopManager::IsEStopped()
 
 int64_t EStopManager::LastEStopped()
 {
-  return s_estopActivatedAt.load(std::memory_order_acquire);
+  return s_estopActivatedAt.load(std::memory_order_relaxed);
 }
 
 void EStopManager::SoftwareTrigger()

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -242,10 +242,10 @@ static bool estopmgr_setPinImpl(gpio_num_t pin)
     return false;
   }
 
-  gpio_num_t oldPin = s_estopPin;
+  gpio_num_t oldPin = s_estopPin.load(std::memory_order_acquire);
 
   // Set the new pin
-  s_estopPin = pin;
+  s_estopPin.store(pin, std::memory_order_release);
 
   if (oldPin != GPIO_NUM_NC) {
     // Reset the old pin

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -42,7 +42,7 @@ static std::atomic<bool> s_killEStopManagerRequested = false;
 
 static bool s_estopInitialized = false;
 
-static void estopmgr_PublishState(EStopState state, EStopState& lastState)
+static void estopmgr_publishState(EStopState state, EStopState& lastState)
 {
   if (state == lastState) {
     return;  // No state change -> no event
@@ -59,8 +59,10 @@ static void estopmgr_PublishState(EStopState state, EStopState& lastState)
 }
 
 // Samples the estop at a fixed rate and updates internal state + events
-static void estopmgr_ManagerTask(void* pvParameters)
+static void estopmgr_managerTask(void* pvParameters)
 {
+  (void)pvParameters;
+
   // Ensure known initial state
   s_estopActivatedAt.store(0, std::memory_order_relaxed);
 
@@ -80,9 +82,8 @@ static void estopmgr_ManagerTask(void* pvParameters)
   // Debounced button state: true == pressed, false == released
   bool lastBtnState = false;
 
-  for (;;) {
-    // Check if killing manager was requested
-    if (s_killEStopManagerRequested.load(std::memory_order_relaxed)) break;
+  // Check if killing manager was requested, continue looping otherwise
+  while (!s_killEStopManagerRequested.load(std::memory_order_relaxed)) {
 
     // Sleep for the update rate
     vTaskDelay(pdMS_TO_TICKS(k_estopUpdateRate));
@@ -92,9 +93,7 @@ static void estopmgr_ManagerTask(void* pvParameters)
 
     // Handle external trigger: forcibly set the E-Stop active.
     if (s_externallyTriggered.exchange(false, std::memory_order_acquire)) {
-      if (s_estopActivatedAt.load(std::memory_order_acquire) == 0) {
-        s_estopActivatedAt.store(now, std::memory_order_release);
-      }
+      s_estopActivatedAt.compare_exchange_strong(0, now, std::memory_order_acq_rel);
       
       state        = EStopState::Active;
       rearmBlocked = false;

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -94,7 +94,7 @@ static void estopmgr_managerTask(void* pvParameters)
     // Handle external trigger: forcibly set the E-Stop active.
     if (s_externallyTriggered.exchange(false, std::memory_order_acquire)) {
       int64_t zero = 0;
-      s_estopActivatedAt.compare_exchange_strong(zero, now, std::memory_order_acq_rel);
+      s_estopActivatedAt.compare_exchange_strong(zero, now, std::memory_order_acquire);
       
       state        = EStopState::Active;
       rearmBlocked = false;

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -183,7 +183,7 @@ static bool estopmgr_setEStopEnabled(bool enabled)
 {
   if (enabled) {
     if (s_estopTask == nullptr) {
-      s_killEStopManagerRequested.store(false, std::memory_order_acquire);
+      s_killEStopManagerRequested.store(false, std::memory_order_release);
       if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, 4096, nullptr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
         OS_LOGE(TAG, "Failed to create EStop event handler task");
         s_estopTask = nullptr;
@@ -194,7 +194,7 @@ static bool estopmgr_setEStopEnabled(bool enabled)
     }
   } else {
     if (s_estopTask != nullptr) {
-      s_killEStopManagerRequested.store(true, std::memory_order_acquire);
+      s_killEStopManagerRequested.store(true, std::memory_order_release);
       s_estopActivatedAt.store(0, std::memory_order_relaxed);
       
       TaskUtils::StopTask(s_estopTask, TAG, "EStop task");

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -42,19 +42,19 @@ static std::atomic<bool> s_killEStopManagerRequested = false;
 
 static bool s_estopInitialized = false;
 
-static void estopmgr_publishState(EStopState state, EStopState& lastState)
+static void estopmgr_publishState(EStopState state, EStopState& lastState, TickType_t timeout = pdMS_TO_TICKS(750))
 {
   if (state == lastState) {
     return;  // No state change -> no event
   }
 
   // Post the current state as the event payload
-  esp_err_t err = esp_event_post(OPENSHOCK_EVENTS, OPENSHOCK_EVENT_ESTOP_STATE_CHANGED, &state, sizeof(state), pdMS_TO_TICKS(750));
+  esp_err_t err = esp_event_post(OPENSHOCK_EVENTS, OPENSHOCK_EVENT_ESTOP_STATE_CHANGED, &state, sizeof(state), timeout);
 
   if (err == ESP_OK) {
     lastState = state;
   } else {
-    OS_LOGE(TAG, "Failed to publish EStop event");
+    OS_LOGE(TAG, "Failed to publish EStop event: %s", esp_err_to_name(err));
   }
 }
 
@@ -62,7 +62,7 @@ static void estopmgr_publishState(EStopState state, EStopState& lastState)
 static void estopmgr_managerTask(void* pvParameters)
 {
   // Pin is being passed as a pointer, cast it back to gpio number type to get pin value
-  gpio_num_t estopPin = static_cast<gpio_num_t>(reinterpret_cast<intptr_t>(pvParameters));
+  gpio_num_t estopPin = static_cast<gpio_num_t>(reinterpret_cast<uintptr_t>(pvParameters));
 
   // Ensure known initial state
   s_estopActivatedAt.store(0, std::memory_order_relaxed);
@@ -171,23 +171,21 @@ static void estopmgr_managerTask(void* pvParameters)
   }
 
   // Broke out of main loop, set global variables to Idle state.
-  estopmgr_publishState(EStopState::Idle, lastPublishedState);
+  // Use a blocking publish so downstream consumers (keep-alive gating, visuals)
+  // are guaranteed to observe the Idle transition even under event-loop pressure.
+  estopmgr_publishState(EStopState::Idle, lastPublishedState, portMAX_DELAY);
   s_estopActivatedAt.store(0, std::memory_order_relaxed);
 
   vTaskDelete(nullptr);
 }
 
-static bool estopmgr_setPinImpl(gpio_num_t pin)
+// Validates and configures `pin` as an EStop input. Does not touch s_estopPin
+// or any other pin — caller owns the s_estopPin assignment and old-pin release.
+static bool estopmgr_configurePin(gpio_num_t pin)
 {
-  esp_err_t err;
-
   if (!OpenShock::IsValidInputPin(pin)) {
     OS_LOGE(TAG, "Invalid EStop pin: %hhi", static_cast<int8_t>(pin));
     return false;
-  }
-
-  if (s_estopPin == pin) {
-    return true;
   }
 
   // Configure the new pin
@@ -199,27 +197,25 @@ static bool estopmgr_setPinImpl(gpio_num_t pin)
     .intr_type    = GPIO_INTR_DISABLE,
   };
 
-  err = gpio_config(&io_conf);
+  esp_err_t err = gpio_config(&io_conf);
   if (err != ESP_OK) {
-    OS_LOGE(TAG, "Failed to configure EStop pin");
+    OS_LOGE(TAG, "Failed to configure EStop pin: %s", esp_err_to_name(err));
     return false;
   }
 
-  gpio_num_t oldPin = s_estopPin;
+  return true;
+}
 
-  // Set the new pin
-  s_estopPin = pin;
-
-  if (oldPin != GPIO_NUM_NC) {
-    // Reset the old pin
-    err = gpio_reset_pin(oldPin);
-    if (err != ESP_OK) {
-      OS_LOGE(TAG, "Failed to reset old EStop pin");
-      return false;
-    }
+static void estopmgr_releasePin(gpio_num_t pin)
+{
+  if (pin == GPIO_NUM_NC) {
+    return;
   }
 
-  return true;
+  esp_err_t err = gpio_reset_pin(pin);
+  if (err != ESP_OK) {
+    OS_LOGE(TAG, "Failed to reset old EStop pin: %s", esp_err_to_name(err));
+  }
 }
 
 static bool estopmgr_taskStart()
@@ -241,10 +237,11 @@ static bool estopmgr_taskStart()
       return false;
     }
 
-    if (!estopmgr_setPinImpl(pin)) {
-      OS_LOGE(TAG, "Failed to set EStop pin");
+    if (!estopmgr_configurePin(pin)) {
       return false;
     }
+
+    s_estopPin = pin;
   }
 
   s_killEStopManagerRequested.store(false, std::memory_order_relaxed);
@@ -258,8 +255,8 @@ static bool estopmgr_taskStart()
   // will not change between creating the task and it freezing its local copy of the value.
   //
   // This enables us to use no allocations or atomic operations
-  static_assert(sizeof(void*) >= sizeof(gpio_num_t), "void* is smaller than gpio_num_t, value embedding trick wont work");  // Just to be safe
-  void* argPtr = reinterpret_cast<void*>(static_cast<intptr_t>(s_estopPin));
+  static_assert(sizeof(void*) >= sizeof(gpio_num_t), "void* is smaller than gpio_num_t, value embedding trick won't work");  // Just to be safe
+  void* argPtr = reinterpret_cast<void*>(static_cast<uintptr_t>(s_estopPin));
 
   if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, 4096, argPtr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
     OS_LOGE(TAG, "Failed to create EStop event handler task");
@@ -307,10 +304,11 @@ bool EStopManager::Init()
 
   OpenShock::ScopedLock lock__(&s_estopMutex);
 
-  if (!estopmgr_setPinImpl(cfg.gpioPin)) {
-    OS_LOGE(TAG, "Failed to set EStop pin");
+  if (!estopmgr_configurePin(cfg.gpioPin)) {
     return false;
   }
+
+  s_estopPin = cfg.gpioPin;
 
   return estopmgr_taskStart();
 }
@@ -330,28 +328,41 @@ bool EStopManager::SetEStopPin(gpio_num_t pin)
 {
   OpenShock::ScopedLock lock__(&s_estopMutex);
 
-  // Check pin validity before stopping possibly running task
-  if (!OpenShock::IsValidInputPin(pin)) {
-    OS_LOGE(TAG, "Invalid EStop pin: %hhi", static_cast<int8_t>(pin));
-    return false;
-  }
-
   if (s_estopPin == pin) {
     return true;
   }
 
-  bool wasRunning = s_estopTask != nullptr;
+  // 1+2: validate and configure the new pin. On failure, nothing has changed —
+  // old pin is still wired up and the task (if any) keeps sampling it.
+  if (!estopmgr_configurePin(pin)) {
+    return false;
+  }
+
+  gpio_num_t oldPin = s_estopPin;
+  bool wasRunning   = s_estopTask != nullptr;
+
+  // 3: stop the task before swapping s_estopPin, so the global never disagrees
+  // with what the sampling task is actually reading.
   if (wasRunning && !estopmgr_taskStop()) {
+    // Undo step 2: release the just-configured pin; old pin/task untouched.
+    estopmgr_releasePin(pin);
     return false;
   }
 
-  if (!estopmgr_setPinImpl(pin)) {
-    return false;
-  }
+  // 4: swap (safe — task is stopped).
+  s_estopPin = pin;
 
+  // 5: restart on the new pin.
   if (wasRunning && !estopmgr_taskStart()) {
+    // Task is dead and we can't bring it back. The old pin is no longer being
+    // sampled by anyone, so release it. Device is left without an active
+    // EStop manager — unrecoverable.
+    estopmgr_releasePin(oldPin);
     return false;
   }
+
+  // 6: release the old pin now that nothing is sampling it.
+  estopmgr_releasePin(oldPin);
 
   return true;
 }

--- a/src/EStopManager.cpp
+++ b/src/EStopManager.cpp
@@ -28,7 +28,10 @@ const uint32_t k_estopCheckCount      = 13;                                     
 const uint16_t k_estopCheckMask       = 0xFFFF >> ((sizeof(uint16_t) * 8) - k_estopCheckCount);  // Mask to check only last k_estopCheckCount bits within history
 
 // Grace period after deactivation (prevents immediate re-trigger on release bounce/EMI)
-const uint32_t k_estopRearmGraceTime = 250;  // tune as needed
+const uint32_t k_estopRearmGraceTime = 250;    // tune as needed
+
+const uint32_t k_estopTaskStackSize   = 4096;  // TODO: profile and tune
+const UBaseType_t k_estopTaskPriority = 5;
 
 static OpenShock::SimpleMutex s_estopMutex = {};
 // Guarded via Mutex
@@ -180,7 +183,7 @@ static void estopmgr_managerTask(void* pvParameters)
 }
 
 // Validates and configures `pin` as an EStop input. Does not touch s_estopPin
-// or any other pin — caller owns the s_estopPin assignment and old-pin release.
+// or any other pin; caller owns the s_estopPin assignment and old-pin release.
 static bool estopmgr_configurePin(gpio_num_t pin)
 {
   if (!OpenShock::IsValidInputPin(pin)) {
@@ -226,7 +229,7 @@ static bool estopmgr_taskStart()
   }
 
   if (s_estopPin == GPIO_NUM_NC) {
-    gpio_num_t pin;
+    gpio_num_t pin = GPIO_NUM_NC;
     if (!OpenShock::Config::GetEStopGpioPin(pin)) {
       OS_LOGE(TAG, "Failed to get EStop pin from config");
       return false;
@@ -258,7 +261,7 @@ static bool estopmgr_taskStart()
   static_assert(sizeof(void*) >= sizeof(gpio_num_t), "void* is smaller than gpio_num_t, value embedding trick won't work");  // Just to be safe
   void* argPtr = reinterpret_cast<void*>(static_cast<uintptr_t>(s_estopPin));
 
-  if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, 4096, argPtr, 5, &s_estopTask, 1) != pdPASS) {  // TODO: Profile stack size and set priority
+  if (TaskUtils::TaskCreateUniversal(estopmgr_managerTask, TAG, k_estopTaskStackSize, argPtr, k_estopTaskPriority, &s_estopTask, 1) != pdPASS) {
     OS_LOGE(TAG, "Failed to create EStop event handler task");
     s_estopTask = nullptr;
     return false;
@@ -319,9 +322,9 @@ bool EStopManager::SetEStopEnabled(bool enabled)
 
   if (enabled) {
     return estopmgr_taskStart();
-  } else {
-    return estopmgr_taskStop();
   }
+
+  return estopmgr_taskStop();
 }
 
 bool EStopManager::SetEStopPin(gpio_num_t pin)
@@ -332,8 +335,8 @@ bool EStopManager::SetEStopPin(gpio_num_t pin)
     return true;
   }
 
-  // 1+2: validate and configure the new pin. On failure, nothing has changed —
-  // old pin is still wired up and the task (if any) keeps sampling it.
+  // Configure the new pin before touching anything else. If this fails the
+  // running task keeps sampling the old pin and the manager stays healthy.
   if (!estopmgr_configurePin(pin)) {
     return false;
   }
@@ -341,27 +344,23 @@ bool EStopManager::SetEStopPin(gpio_num_t pin)
   gpio_num_t oldPin = s_estopPin;
   bool wasRunning   = s_estopTask != nullptr;
 
-  // 3: stop the task before swapping s_estopPin, so the global never disagrees
-  // with what the sampling task is actually reading.
+  // Stop the task before swapping s_estopPin so the global can't disagree
+  // with what the task is actually reading.
   if (wasRunning && !estopmgr_taskStop()) {
-    // Undo step 2: release the just-configured pin; old pin/task untouched.
+    // Roll back the configuration we just did; old pin and task are untouched.
     estopmgr_releasePin(pin);
     return false;
   }
 
-  // 4: swap (safe — task is stopped).
   s_estopPin = pin;
 
-  // 5: restart on the new pin.
   if (wasRunning && !estopmgr_taskStart()) {
-    // Task is dead and we can't bring it back. The old pin is no longer being
-    // sampled by anyone, so release it. Device is left without an active
-    // EStop manager — unrecoverable.
+    // Task is gone and we can't bring it back. The old pin is no longer being
+    // sampled so we release it, but the manager is left inactive.
     estopmgr_releasePin(oldPin);
     return false;
   }
 
-  // 6: release the old pin now that nothing is sampling it.
   estopmgr_releasePin(oldPin);
 
   return true;

--- a/src/message_handlers/websocket/gateway/Trigger.cpp
+++ b/src/message_handlers/websocket/gateway/Trigger.cpp
@@ -34,7 +34,7 @@ void _Private::HandleTrigger(const OpenShock::Serialization::Gateway::GatewayToH
       esp_restart();
       break;
     case TriggerType::EmergencyStop:
-      EStopManager::Trigger();
+      EStopManager::SoftwareTrigger();
       break;
     case TriggerType::CaptivePortalEnable:
       OpenShock::CaptivePortal::SetAlwaysEnabled(true);


### PR DESCRIPTION
This PR aims to reduce the use of atomics and global `static` variables within the EStop manager, and improve the resiliency of the ones that are remain required.

Additionally, the EStop manager now resets back to the Idle state when being disabled or when changing the pin (otherwise you could not disable it if it was falsely triggered prior to disabling, or if the previously-chosen pin was incorrect and would always read Low).