### PR TITLE
Keep Alive timeout with auto reconnect

### DIFF
--- a/.changeset/keepalive-timeout-reconnect.md
+++ b/.changeset/keepalive-timeout-reconnect.md
@@ -1,0 +1,5 @@
+---
+'firmware': minor
+---
+
+feat: add a keepalive ping timeout that forces a reconnect on backend connection loss

--- a/include/GatewayClient.h
+++ b/include/GatewayClient.h
@@ -28,6 +28,8 @@ namespace OpenShock {
     bool sendMessageTXT(std::string_view data);
     bool sendMessageBIN(tcb::span<const uint8_t> data);
 
+    void markPingReceived();
+
     bool loop();
 
   private:
@@ -37,5 +39,6 @@ namespace OpenShock {
 
     WebSocketsClient m_webSocket;
     GatewayClientState m_state;
+    int64_t m_lastPingTimestamp;
   };
 }  // namespace OpenShock

--- a/include/GatewayConnectionManager.h
+++ b/include/GatewayConnectionManager.h
@@ -19,5 +19,7 @@ namespace OpenShock::GatewayConnectionManager {
   bool SendMessageTXT(std::string_view data);
   bool SendMessageBIN(tcb::span<const uint8_t> data);
 
+  void MarkPingReceived();
+
   void Update();
 }  // namespace OpenShock::GatewayConnectionManager

--- a/src/GatewayClient.cpp
+++ b/src/GatewayClient.cpp
@@ -14,11 +14,14 @@ const char* const TAG = "GatewayClient";
 
 using namespace OpenShock;
 
+const int64_t GATEWAY_PING_TIMEOUT = 90'000;
+
 static bool s_bootStatusSent = false;
 
 GatewayClient::GatewayClient(const std::string& authToken)
   : m_webSocket()
   , m_state(GatewayClientState::Disconnected)
+  , m_lastPingTimestamp(0)
 {
   OS_LOGD(TAG, "Creating GatewayClient");
 
@@ -90,6 +93,11 @@ bool GatewayClient::sendMessageBIN(tcb::span<const uint8_t> data)
   return m_webSocket.sendBIN(data.data(), data.size());
 }
 
+void GatewayClient::markPingReceived()
+{
+  m_lastPingTimestamp = OpenShock::millis();
+}
+
 bool GatewayClient::loop()
 {
   if (m_state == GatewayClientState::Disconnected) {
@@ -102,6 +110,13 @@ bool GatewayClient::loop()
   if (m_state != GatewayClientState::Connected) {
     // return true to indicate that we are still busy
     return true;
+  }
+
+  if (m_lastPingTimestamp != 0 && (OpenShock::millis() - m_lastPingTimestamp) > GATEWAY_PING_TIMEOUT) {
+    OS_LOGW(TAG, "No ping received from gateway for %lld ms, forcing reconnect", GATEWAY_PING_TIMEOUT);
+    m_webSocket.disconnect();
+    _setState(GatewayClientState::Disconnected);
+    return false;
   }
 
   return true;

--- a/src/GatewayClient.cpp
+++ b/src/GatewayClient.cpp
@@ -175,6 +175,7 @@ void GatewayClient::_handleEvent(WStype_t type, uint8_t* payload, std::size_t le
       _setState(GatewayClientState::Disconnected);
       break;
     case WStype_CONNECTED:
+      m_lastPingTimestamp = 0;
       _setState(GatewayClientState::Connected);
       _sendBootStatus();
       break;

--- a/src/GatewayConnectionManager.cpp
+++ b/src/GatewayConnectionManager.cpp
@@ -194,6 +194,16 @@ bool GatewayConnectionManager::SendMessageBIN(tcb::span<const uint8_t> data)
   return client->sendMessageBIN(data);
 }
 
+void GatewayConnectionManager::MarkPingReceived()
+{
+  auto client = GetClient();
+  if (client == nullptr) {
+    return;
+  }
+
+  client->markPingReceived();
+}
+
 bool FetchHubInfo(std::string authToken)
 {
   // TODO: this function is very slow, should be optimized!

--- a/src/message_handlers/websocket/gateway/Ping.cpp
+++ b/src/message_handlers/websocket/gateway/Ping.cpp
@@ -18,5 +18,6 @@ void _Private::HandlePing(const OpenShock::Serialization::Gateway::GatewayToHubM
     return;
   }
 
+  GatewayConnectionManager::MarkPingReceived();
   Serialization::Gateway::SerializePongMessage(GatewayConnectionManager::SendMessageBIN);
 }


### PR DESCRIPTION
Our ping pong keep alive should have a timeout timer, which forces a reconnect if the backend websocket stops sending pings, which would indicate a connection failure.