### PR TITLE
chore: pin GitHub Actions and Docker images to digests

### DIFF
--- a/.github/actions/build-compilationdb/action.yml
+++ b/.github/actions/build-compilationdb/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         env: ci-build
 
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         cache: 'pip'
 

--- a/.github/actions/build-firmware/action.yml
+++ b/.github/actions/build-firmware/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         env: ${{ inputs.board }}
 
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         cache: 'pip'
 
@@ -38,7 +38,7 @@ runs:
         OPENSHOCK_FW_GIT_COMMIT: ${{ github.sha }}
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: firmware_build_${{ inputs.board }}
         path: .pio/build/${{ inputs.board }}/*.bin

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -4,11 +4,11 @@ description: Builds the frontend and uploads it as an artifact
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version-file: ./frontend/package.json
 
-    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       name: Install pnpm
       with:
           cache: true
@@ -41,7 +41,7 @@ runs:
       run: pnpm run build
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: frontend
         path: frontend/build/*

--- a/.github/actions/build-staticfs/action.yml
+++ b/.github/actions/build-staticfs/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         env: fs
 
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         cache: 'pip'
 
@@ -21,7 +21,7 @@ runs:
       run: pip install -r requirements.txt
 
     - name: Download built frontend
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: frontend
         path: frontend/build/
@@ -43,7 +43,7 @@ runs:
       run: mv .pio/build/fs/littlefs.bin staticfs.bin
 
     - name: Upload internal filesystem artifact
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: firmware_staticfs
         path: staticfs.bin

--- a/.github/actions/cdn-upload-firmware/action.yml
+++ b/.github/actions/cdn-upload-firmware/action.yml
@@ -24,7 +24,7 @@ runs:
     # partition plus each board's build partitions and merged binary. They land
     # under artifacts/<artifact-name>/ so the loop below can pick them per board.
     - name: Download firmware artifacts
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: artifacts
         pattern: firmware_*

--- a/.github/actions/merge-partitions/action.yml
+++ b/.github/actions/merge-partitions/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         cache: 'pip'
 
@@ -20,12 +20,12 @@ runs:
       run: pip install -r requirements.txt
 
     - name: Download static filesystem partition
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: firmware_staticfs
 
     - name: Download firmware partitions
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: firmware_build_${{ inputs.board }}
 
@@ -36,7 +36,7 @@ runs:
         mv merged.bin OpenShock_${{ inputs.board }}_${{ inputs.version }}.bin
 
     - name: Upload merged firmware binary
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: firmware_merged_${{ inputs.board }}
         path: OpenShock_${{ inputs.board }}_*.bin

--- a/.github/actions/pio-cache/action.yml
+++ b/.github/actions/pio-cache/action.yml
@@ -36,7 +36,7 @@ runs:
     # entry instead of each storing its own copy. ~/.platformio/.cache (the
     # downloaded archives) is deliberately NOT cached: the extracted packages
     # cache already avoids re-downloads, and caching it roughly doubled the size.
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.platformio/platforms
@@ -48,7 +48,7 @@ runs:
     # Library sources live in per-env directories. lib_deps is global so the
     # contents are identical across boards, but PlatformIO stores them under
     # .pio/libdeps/<env>, so key them per-env. This slice is small.
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .pio/libdeps
         key: pio-libdeps-${{ runner.os }}-${{ inputs.env }}-${{ hashFiles('platformio.ini') }}

--- a/.github/workflows/check-changes.yml
+++ b/.github/workflows/check-changes.yml
@@ -17,12 +17,12 @@ jobs:
       !github.event.pull_request.draft &&
       !contains(github.event.pull_request.labels.*.name, 'no-changelog')
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Run change file check
-        uses: OpenShock/release-tool@f3e8ebc530022e209e4d6a9a9c8bdb30b643253f  # v0.3.0
+        uses: OpenShock/release-tool@f3e8ebc530022e209e4d6a9a9c8bdb30b643253f # v0.3.0
         with:
           mode: check
           base-ref: ${{ github.event.pull_request.base.ref }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upload verdict
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-check
           path: release-check.json

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -87,7 +87,7 @@ jobs:
       # deploy always implies build.
       - name: Decide build vs deploy
         id: decide
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { eventName, ref, sha } = context;
@@ -167,7 +167,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           sparse-checkout: |
@@ -182,7 +182,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/build-staticfs
         with:
           version: ${{ needs.getvars.outputs.version }}
@@ -197,7 +197,7 @@ jobs:
       matrix: ${{ fromJSON(needs.getvars.outputs.board-matrix) }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/build-firmware
         with:
@@ -213,7 +213,7 @@ jobs:
       matrix: ${{ fromJSON(needs.getvars.outputs.board-matrix) }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             .github
@@ -253,7 +253,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             .github
@@ -327,7 +327,7 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so cdn-bump-version can resolve the commit date of the
           # version currently pinned on the develop channel (X.Y.Z-develop+<sha>)
@@ -359,7 +359,7 @@ jobs:
       # artifact (frontend, per-board partitions, staticfs) just to glob for the
       # merged images is wasteful.
       - name: Download release artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: firmware_merged_*
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,23 +42,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c35d1b164463ee62a100735382aaaa525c5d3496  # codeql-bundle-v2.25.6
+        uses: github/codeql-action/init@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@c35d1b164463ee62a100735382aaaa525c5d3496  # codeql-bundle-v2.25.6
+        uses: github/codeql-action/autobuild@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
 
       # Build stuff here
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c35d1b164463ee62a100735382aaaa525c5d3496  # codeql-bundle-v2.25.6
+        uses: github/codeql-action/analyze@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
         with:
           category: '/language:${{matrix.language}}'
 
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@c35d1b164463ee62a100735382aaaa525c5d3496  # codeql-bundle-v2.25.6
+        uses: github/codeql-action/init@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
         with:
           languages: ${{ env.language }}
 
@@ -90,6 +90,6 @@ jobs:
           version: 0.0.0-codeql+build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@c35d1b164463ee62a100735382aaaa525c5d3496  # codeql-bundle-v2.25.6
+        uses: github/codeql-action/analyze@e58424170fb0262c8d7ed60a2e84b9bffe205c67 # codeql-bundle-v2.26.1
         with:
           category: '/language:${{ env.language }}'

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -27,13 +27,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/build-compilationdb
         with:
           version: 0.0.0-test+build # Doesn't matter, just need the compilation database
       
-      - uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed  # v2.20.0
+      - uses: cpp-linter/cpp-linter-action@8e85cd02c8c3fe3ae527c94b5683fe2366b144ed # v2.20.0
         id: linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/get-vars.yml
+++ b/.github/workflows/get-vars.yml
@@ -34,7 +34,7 @@ jobs:
       board-matrix: ${{ steps.get-vars.outputs.board-matrix }}
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           sparse-checkout: |
@@ -43,11 +43,11 @@ jobs:
 
       # Pin Node to the range declared in the scripts package (engines.node),
       # rather than relying on whatever the runner image happens to ship.
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .github/scripts/package.json
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
           cache: true
@@ -63,7 +63,7 @@ jobs:
       # labelled as a pre-release of the upcoming version instead of the last tag.
       - name: Compute next version
         id: relmeta
-        uses: OpenShock/release-tool@f3e8ebc530022e209e4d6a9a9c8bdb30b643253f  # v0.3.0
+        uses: OpenShock/release-tool@f3e8ebc530022e209e4d6a9a9c8bdb30b643253f # v0.3.0
         with:
           mode: status
 

--- a/.github/workflows/pr-check-comment.yml
+++ b/.github/workflows/pr-check-comment.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Download verdict
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-check
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
       # triggers ci-build; the default GITHUB_TOKEN does not trigger downstream
       # workflows. Using an App (instead of a personal PAT) keeps the token
       # short-lived, least-privilege, and owned by the org rather than a person.
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_KEY }}
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run release tool
         id: meta
-        uses: OpenShock/release-tool@f3e8ebc530022e209e4d6a9a9c8bdb30b643253f  # v0.3.0
+        uses: OpenShock/release-tool@f3e8ebc530022e209e4d6a9a9c8bdb30b643253f # v0.3.0
         with:
           mode: release
           output: release.json


### PR DESCRIPTION
Automated dependency pinning by the HeavenVR maintenance bot:

- GitHub Actions `uses:` refs upgraded to their latest release tag and pinned to the commit SHA that tag resolves to
- Dockerfile `FROM` images pinned to their current `@sha256` digest


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/Firmware/pull/495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->