### PR TITLE
chore: stagger dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: monday
       time: '06:00'
     groups:
       ci-cd:
@@ -26,7 +26,7 @@ updates:
     directory: '/.github/scripts'
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: monday
       time: '06:00'
     groups:
       ci-cd:
@@ -42,7 +42,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: monday
       time: '06:00'
     groups:
       build-system:
@@ -58,7 +58,7 @@ updates:
     directory: '/frontend'
     schedule:
       interval: 'weekly'
-      day: 'monday'
+      day: monday
       time: '06:00'
     groups:
       frontend:


### PR DESCRIPTION
Automated by the HeavenVR maintenance bot: moves this repo's dependabot update schedule to Monday at 06:00, so PRs land spread across the week instead of every repo in the org opening PRs at the same Monday 06:00 slot.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/OpenShock/Firmware/pull/496">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->